### PR TITLE
Sorry BusyBox, you've been disrupted.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -49,7 +49,6 @@
   <project path="external/boringssl" name="CyanogenMod/android_external_boringssl" groups="pdk" />
   <project path="external/bouncycastle" name="CyanogenMod/android_external_bouncycastle" groups="pdk" />
   <project path="external/brctl" name="CyanogenMod/android_external_brctl" />
-  <project path="external/busybox" name="CyanogenMod/android_external_busybox" />
   <project path="external/connectivity" name="CyanogenMod/android_external_connectivity" />
   <project path="external/curl" name="CyanogenMod/android_external_curl" />
   <project path="external/dhcpcd" name="CyanogenMod/android_external_dhcpcd" groups="pdk-cw-fs,pdk-fs" />


### PR DESCRIPTION
- Android has fully embraced Toybox in AOSP to replace most of Toolbox
  and provide a semi-functional commandline environment.
- We are currently using the master branch of AOSP, with a few of our
  own changes. This covers about 90% of the cases where Busybox was
  used. For the remaining stuff (compression tools, etc) I've brought
  in extra packages or other fixes in order to cover the gaps.
- I suspect this will be controversial, but at this point BusyBox is
  deprecated and Toybox is the future.
- Thank you to everyone (Tanguy, the Android x86 team, Dan, etc) who
  have maintained this port to Android over the years!

Change-Id: I74627a294bb198b28d6727e9b78b72582b1b0ad3
